### PR TITLE
E2E - Enhance Mandatory MFA scenarios if the token is invalid

### DIFF
--- a/authservice/login-with-passwordless/AuthServicePage.ts
+++ b/authservice/login-with-passwordless/AuthServicePage.ts
@@ -54,6 +54,23 @@ export class AuthServicePage {
     });
 
     await this.page.locator(`xpath=.//input[@data-test='single-input']`).first().type(token);
+
+    await delay(2000);
+    if (await this.page.locator('text="Invalid OTP, please try again"').isVisible()) {
+      await this.page.locator(`xpath=.//input[@data-test='single-input']`).last().click();
+
+      for (let index = 0; index < 6; index++) {
+        await this.page.keyboard.press("Delete");
+      }
+
+      const newToken = speakeasy.totp({
+        secret,
+        encoding: "base32",
+        step: 30,
+      });
+
+      await this.page.locator(`xpath=.//input[@data-test='single-input']`).first().type(newToken);
+    }
   }
 
   async setupAuthenticator() {

--- a/authservice/login-with-passwordless/auth-case-3.test.ts
+++ b/authservice/login-with-passwordless/auth-case-3.test.ts
@@ -8,7 +8,7 @@ import { LoginPage } from "./LoginPage";
 const passwordTestingFactor = "Testing@123";
 
 test.describe.serial("Passwordless Login scenarios", () => {
-  test.setTimeout(90000);
+  test.setTimeout(120000);
 
   test("Login email passwordless case 3, mandatory MFA then setup 2FA @mandatorymfa", async ({ page, browser }) => {
     const testEmail = generateEmailWithTag();


### PR DESCRIPTION
## Motivation and Context
Test is not stable sometimes because of the invalid token
Work around to re-input the token

Jira Link:
https://toruslabs.atlassian.net/browse/PD-3787
https://github.com/Web3Auth/web3auth-e2e-tests/actions/runs/10463993434


## Description
Increase the timeout to 120s
Handle to re-input the token


## How has this been tested?
Run locally
Check by Github action

## Screenshots (if appropriate):

## Types of changes
Enhance script

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
